### PR TITLE
Move `main`'s arguments out into separate imports.

### DIFF
--- a/command.md
+++ b/command.md
@@ -19,6 +19,9 @@
 <li>interface <a href="#environment"><code>environment</code></a></li>
 <li>interface <a href="#environment_preopens"><code>environment-preopens</code></a></li>
 <li>interface <a href="#exit"><code>exit</code></a></li>
+<li>interface <a href="#stdin"><code>stdin</code></a></li>
+<li>interface <a href="#stdout"><code>stdout</code></a></li>
+<li>interface <a href="#stderr"><code>stderr</code></a></li>
 </ul>
 </li>
 <li>Exports:
@@ -2582,6 +2585,45 @@ values each time it is called.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="exit.status"><code>status</code></a>: result</li>
+</ul>
+<h2><a name="stdin">Import interface stdin</a></h2>
+<hr />
+<h3>Types</h3>
+<h4><a name="input_stream"><code>type input-stream</code></a></h4>
+<p><a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></p>
+<p>
+----
+<h3>Functions</h3>
+<h4><a name="get_stdin"><code>get-stdin: func</code></a></h4>
+<h5>Return values</h5>
+<ul>
+<li><a name="get_stdin.0"></a> <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+</ul>
+<h2><a name="stdout">Import interface stdout</a></h2>
+<hr />
+<h3>Types</h3>
+<h4><a name="output_stream"><code>type output-stream</code></a></h4>
+<p><a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></p>
+<p>
+----
+<h3>Functions</h3>
+<h4><a name="get_stdout"><code>get-stdout: func</code></a></h4>
+<h5>Return values</h5>
+<ul>
+<li><a name="get_stdout.0"></a> <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+</ul>
+<h2><a name="stderr">Import interface stderr</a></h2>
+<hr />
+<h3>Types</h3>
+<h4><a name="output_stream"><code>type output-stream</code></a></h4>
+<p><a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></p>
+<p>
+----
+<h3>Functions</h3>
+<h4><a name="get_stderr"><code>get-stderr: func</code></a></h4>
+<h5>Return values</h5>
+<ul>
+<li><a name="get_stderr.0"></a> <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
 </ul>
 <h2><a name="run">Export interface run</a></h2>
 <hr />

--- a/command.md
+++ b/command.md
@@ -19,14 +19,11 @@
 <li>interface <a href="#environment"><code>environment</code></a></li>
 <li>interface <a href="#environment_preopens"><code>environment-preopens</code></a></li>
 <li>interface <a href="#exit"><code>exit</code></a></li>
-<li>type <a href="#input_stream"><code>input-stream</code></a></li>
-<li>type <a href="#output_stream"><code>output-stream</code></a></li>
-<li>type <a href="#descriptor"><code>descriptor</code></a></li>
 </ul>
 </li>
 <li>Exports:
 <ul>
-<li>function <a href="#main"><code>main</code></a></li>
+<li>interface <a href="#run"><code>run</code></a></li>
 </ul>
 </li>
 </ul>
@@ -2551,19 +2548,31 @@ values each time it is called.</p>
 <ul>
 <li><a name="get_environment.0"></a> list&lt;(<code>string</code>, <code>string</code>)&gt;</li>
 </ul>
+<h4><a name="get_arguments"><code>get-arguments: func</code></a></h4>
+<p>Get the POSIX-style arguments to the program.</p>
+<h5>Return values</h5>
+<ul>
+<li><a name="get_arguments.0"></a> list&lt;<code>string</code>&gt;</li>
+</ul>
 <h2><a name="environment_preopens">Import interface environment-preopens</a></h2>
 <hr />
 <h3>Types</h3>
 <h4><a name="descriptor"><code>type descriptor</code></a></h4>
 <p><a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></p>
 <p>
+#### <a name="input_stream">`type input-stream`</a>
+[`input-stream`](#input_stream)
+<p>
+#### <a name="output_stream">`type output-stream`</a>
+[`output-stream`](#output_stream)
+<p>
 ----
 <h3>Functions</h3>
-<h4><a name="preopens"><code>preopens: func</code></a></h4>
-<p>Return a list of preopens for use in interpreting environment variables.</p>
+<h4><a name="get_directories"><code>get-directories: func</code></a></h4>
+<p>Return the set of of preopened directories, and their path.</p>
 <h5>Return values</h5>
 <ul>
-<li><a name="preopens.0"></a> list&lt;(<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>, <code>string</code>)&gt;</li>
+<li><a name="get_directories.0"></a> list&lt;(<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>, <code>string</code>)&gt;</li>
 </ul>
 <h2><a name="exit">Import interface exit</a></h2>
 <hr />
@@ -2574,29 +2583,12 @@ values each time it is called.</p>
 <ul>
 <li><a name="exit.status"><code>status</code></a>: result</li>
 </ul>
-<h2>Exported types from world <a href="#command"><code>command</code></a></h2>
+<h2><a name="run">Export interface run</a></h2>
 <hr />
-<h3>Types</h3>
-<h4><a name="input_stream"><code>type input-stream</code></a></h4>
-<p><a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></p>
-<p>
-#### <a name="output_stream">`type output-stream`</a>
-[`output-stream`](#output_stream)
-<p>
-#### <a name="descriptor">`type descriptor`</a>
-[`descriptor`](#descriptor)
-<p>
-## Exported functions from world `command`
-<h4><a name="main"><code>main: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="main.stdin"><code>stdin</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
-<li><a name="main.stdout"><code>stdout</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
-<li><a name="main.stderr"><code>stderr</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
-<li><a name="main.args"><code>args</code></a>: list&lt;<code>string</code>&gt;</li>
-<li><a name="main.preopens"><a href="#preopens"><code>preopens</code></a></a>: list&lt;(<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>, <code>string</code>)&gt;</li>
-</ul>
+<h3>Functions</h3>
+<h4><a name="run"><code>run: func</code></a></h4>
+<p>Run the program.</p>
 <h5>Return values</h5>
 <ul>
-<li><a name="main.0"></a> result</li>
+<li><a name="run.0"></a> result</li>
 </ul>

--- a/wit/command.wit
+++ b/wit/command.wit
@@ -16,5 +16,8 @@ default world command {
   import environment: pkg.environment
   import environment-preopens: pkg.environment-preopens
   import exit: pkg.exit
+  import stdin: pkg.stdio.stdin
+  import stdout: pkg.stdio.stdout
+  import stderr: pkg.stdio.stderr
   export run: pkg.run
 }

--- a/wit/command.wit
+++ b/wit/command.wit
@@ -16,15 +16,5 @@ default world command {
   import environment: pkg.environment
   import environment-preopens: pkg.environment-preopens
   import exit: pkg.exit
-
-  use io.streams.{input-stream, output-stream}
-  use filesystem.types.{descriptor}
-
-  export main: func(
-    stdin: input-stream,
-    stdout: output-stream,
-    stderr: output-stream,
-    args: list<string>,
-    preopens: list<tuple<descriptor, string>>,
-  ) -> result
+  export run: pkg.run
 }

--- a/wit/environment-preopens.wit
+++ b/wit/environment-preopens.wit
@@ -1,6 +1,7 @@
 default interface environment-preopens {
   use filesystem.types.{descriptor}
+  use io.streams.{input-stream, output-stream}
 
-  /// Return a list of preopens for use in interpreting environment variables.
-  preopens: func() -> list<tuple<descriptor, string>>
+  /// Return the set of of preopened directories, and their path.
+  get-directories: func() -> list<tuple<descriptor, string>>
 }

--- a/wit/environment.wit
+++ b/wit/environment.wit
@@ -8,4 +8,7 @@ default interface environment {
   /// in the component model, this import function should return the same
   /// values each time it is called.
   get-environment: func() -> list<tuple<string, string>>
+
+  /// Get the POSIX-style arguments to the program.
+  get-arguments: func() -> list<string>
 }

--- a/wit/run.wit
+++ b/wit/run.wit
@@ -1,0 +1,4 @@
+default interface run {
+  /// Run the program.
+  run: func() -> result
+}

--- a/wit/stdio.wit
+++ b/wit/stdio.wit
@@ -1,0 +1,14 @@
+default interface stdio {
+  use io.streams.{input-stream, output-stream}
+
+  /// Stdio preopens: these are the resources that provide stdin, stdout, and
+  /// stderr.
+  record stdio-preopens {
+    stdin: input-stream,
+    stdout: output-stream,
+    stderr: output-stream,
+  }
+
+  /// Return the set of stdio preopens.
+  get-stdio: func() -> stdio-preopens
+}

--- a/wit/stdio.wit
+++ b/wit/stdio.wit
@@ -1,14 +1,17 @@
-default interface stdio {
-  use io.streams.{input-stream, output-stream}
+interface stdin {
+  use io.streams.{input-stream}
 
-  /// Stdio preopens: these are the resources that provide stdin, stdout, and
-  /// stderr.
-  record stdio-preopens {
-    stdin: input-stream,
-    stdout: output-stream,
-    stderr: output-stream,
-  }
+  get-stdin: func() -> input-stream
+}
 
-  /// Return the set of stdio preopens.
-  get-stdio: func() -> stdio-preopens
+interface stdout {
+  use io.streams.{output-stream}
+
+  get-stdout: func() -> output-stream
+}
+
+interface stderr {
+  use io.streams.{output-stream}
+
+  get-stderr: func() -> output-stream
 }


### PR DESCRIPTION
 - Rename `main` to `run` to avoid colliding with language toolchains that assign special meaning to the name "main".

 - Move `run` to its own interface.

 - Instead of having the `run` function take stdio, command-line arguments, and preopens as arguments, have separate imports for those. This will make it easier to reuse the `run` interface in other worlds with other imports.