### PR TITLE
Rename environment-preopens to just preopens for now.

### DIFF
--- a/command.md
+++ b/command.md
@@ -19,7 +19,7 @@
 <li>interface <a href="#insecure_random"><code>insecure-random</code></a></li>
 <li>interface <a href="#insecure_random_seed"><code>insecure-random-seed</code></a></li>
 <li>interface <a href="#environment"><code>environment</code></a></li>
-<li>interface <a href="#environment_preopens"><code>environment-preopens</code></a></li>
+<li>interface <a href="#preopens"><code>preopens</code></a></li>
 <li>interface <a href="#exit"><code>exit</code></a></li>
 <li>interface <a href="#stdin"><code>stdin</code></a></li>
 <li>interface <a href="#stdout"><code>stdout</code></a></li>
@@ -2923,7 +2923,7 @@ values each time it is called.</p>
 <ul>
 <li><a name="get_arguments.0"></a> list&lt;<code>string</code>&gt;</li>
 </ul>
-<h2><a name="environment_preopens">Import interface environment-preopens</a></h2>
+<h2><a name="preopens">Import interface preopens</a></h2>
 <hr />
 <h3>Types</h3>
 <h4><a name="descriptor"><code>type descriptor</code></a></h4>

--- a/wit/command.wit
+++ b/wit/command.wit
@@ -16,7 +16,7 @@ default world command {
   import poll: poll.poll
   import streams: io.streams
   import environment: pkg.environment
-  import environment-preopens: pkg.environment-preopens
+  import preopens: pkg.preopens
   import exit: pkg.exit
   import stdin: pkg.stdio.stdin
   import stdout: pkg.stdio.stdout

--- a/wit/preopens.wit
+++ b/wit/preopens.wit
@@ -1,4 +1,4 @@
-default interface environment-preopens {
+default interface preopens {
   use filesystem.types.{descriptor}
   use io.streams.{input-stream, output-stream}
 


### PR DESCRIPTION
Environment variables and arguments are currently in the same interface, so we don't need to qualify that the preopens are for environment variables, as they're for both.