### PR TITLE
Add Phase 4 Advancement Criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ wasi-cli is currently in [Phase 1].
 
 ### Phase 4 Advancement Criteria
 
-TODO before entering Phase 2.
+WASI CLI must have host implementations which can pass the testsuite
+on at least Windows, macOS, and Linux.
+
+WASI CLI must have at least two complete independent implementations.
 
 ## Table of Contents
 


### PR DESCRIPTION
Add Phase 4 Advancement Criteria to wasi-cli. This uses the same criteria as wasi-filesystem: support Windows, macOS, and Linux, and have at least two implementations.