### PR TITLE
Add a `reactor` world

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,6 @@ jobs:
         ./wit-deps lock
         git add -N wit/deps
         git diff --exit-code
-    - uses: alexcrichton/wai-abi-up-to-date@update-to-wit-bindgen
+    - uses: WebAssembly/wit-abi-up-to-date@v14
       with:
         worlds: "command reactor"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,6 @@ jobs:
         ./wit-deps lock
         git add -N wit/deps
         git diff --exit-code
-    - uses: alexcrichton/wasi-abi-up-to-date@update-to-wit-bindgen
+    - uses: alexcrichton/wai-abi-up-to-date@update-to-wit-bindgen
       with:
         worlds: "command reactor"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,6 @@ jobs:
         ./wit-deps lock
         git add -N wit/deps
         git diff --exit-code
-    - uses: WebAssembly/wit-abi-up-to-date@v13
+    - uses: alexcrichton/wasi-abi-up-to-date@update-to-wit-bindgen
       with:
-        wit-abi-tag: wit-abi-0.11.0
+        worlds: "command reactor"

--- a/reactor.md
+++ b/reactor.md
@@ -1,4 +1,4 @@
-<h1><a name="command">World command</a></h1>
+<h1><a name="reactor">World reactor</a></h1>
 <ul>
 <li>Imports:
 <ul>
@@ -29,11 +29,6 @@
 <li>interface <a href="#wasi:cli_terminal_stdin"><code>wasi:cli/terminal-stdin</code></a></li>
 <li>interface <a href="#wasi:cli_terminal_stdout"><code>wasi:cli/terminal-stdout</code></a></li>
 <li>interface <a href="#wasi:cli_terminal_stderr"><code>wasi:cli/terminal-stderr</code></a></li>
-</ul>
-</li>
-<li>Exports:
-<ul>
-<li>interface <a href="#wasi:cli_run"><code>wasi:cli/run</code></a></li>
 </ul>
 </li>
 </ul>
@@ -3169,13 +3164,4 @@ allowing further interaction with it.</p>
 <h5>Return values</h5>
 <ul>
 <li><a name="get_terminal_stderr.0"></a> option&lt;<a href="#terminal_output"><a href="#terminal_output"><code>terminal-output</code></a></a>&gt;</li>
-</ul>
-<h2><a name="wasi:cli_run">Export interface wasi:cli/run</a></h2>
-<hr />
-<h3>Functions</h3>
-<h4><a name="run"><code>run: func</code></a></h4>
-<p>Run the program.</p>
-<h5>Return values</h5>
-<ul>
-<li><a name="run.0"></a> result</li>
 </ul>

--- a/wit/command.wit
+++ b/wit/command.wit
@@ -1,32 +1,7 @@
 package wasi:cli
 
 world command {
-  import wasi:clocks/wall-clock
-  import wasi:clocks/monotonic-clock
-  import wasi:clocks/timezone
-  import wasi:filesystem/types
-  import wasi:filesystem/preopens
-  import wasi:sockets/instance-network
-  import wasi:sockets/ip-name-lookup
-  import wasi:sockets/network
-  import wasi:sockets/tcp-create-socket
-  import wasi:sockets/tcp
-  import wasi:sockets/udp-create-socket
-  import wasi:sockets/udp
-  import wasi:random/random
-  import wasi:random/insecure
-  import wasi:random/insecure-seed
-  import wasi:poll/poll
-  import wasi:io/streams
-  import environment
-  import exit
-  import stdin
-  import stdout
-  import stderr
-  import terminal-input
-  import terminal-output
-  import terminal-stdin
-  import terminal-stdout
-  import terminal-stderr
+  include reactor
+
   export run
 }

--- a/wit/reactor.wit
+++ b/wit/reactor.wit
@@ -1,0 +1,30 @@
+world reactor {
+  import wasi:clocks/wall-clock
+  import wasi:clocks/monotonic-clock
+  import wasi:clocks/timezone
+  import wasi:filesystem/types
+  import wasi:filesystem/preopens
+  import wasi:sockets/instance-network
+  import wasi:sockets/ip-name-lookup
+  import wasi:sockets/network
+  import wasi:sockets/tcp-create-socket
+  import wasi:sockets/tcp
+  import wasi:sockets/udp-create-socket
+  import wasi:sockets/udp
+  import wasi:random/random
+  import wasi:random/insecure
+  import wasi:random/insecure-seed
+  import wasi:poll/poll
+  import wasi:io/streams
+  import environment
+  import exit
+  import stdin
+  import stdout
+  import stderr
+  import terminal-input
+  import terminal-output
+  import terminal-stdin
+  import terminal-stdout
+  import terminal-stderr
+}
+


### PR DESCRIPTION
Similar to how there exists a `command` world this commit adds a `reactor` world which has everything that a `command` does except for the export of the `run` interface. This mirrors the `preview1-adapter-reactor` that Wasmtime currently has and is intended to make this available for other WIT-based projects as well.

This commit additionally refactors the preexisting `command` world to replace all of its `import`s with a single `include` of this new `reactor` world.