### PR TITLE
add LICENSE.md from wasi-proposal-template

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,8 @@
+Copyright © 2019-2024 the Contributors to the WASI Specification, published
+by the [WebAssembly Community Group][cg] under the
+[W3C Community Contributor License Agreement (CLA)][cla]. A human-readable
+[summary][summary] is available.
+
+[cg]: https://www.w3.org/community/webassembly/
+[cla]: https://www.w3.org/community/about/agreements/cla/
+[summary]: https://www.w3.org/community/about/agreements/cla-deed/


### PR DESCRIPTION
License is the is the W3C CLA deed. Updated end date to 2024.

Closes https://github.com/WebAssembly/wasi-cli/issues/48