### PR TITLE
feat: Add tmp-dir

### DIFF
--- a/wit/environment.wit
+++ b/wit/environment.wit
@@ -19,4 +19,8 @@ interface environment {
   /// directory, interpreting `.` as shorthand for this.
   @since(version = 0.2.0)
   initial-cwd: func() -> option<string>;
+
+  /// Return a path that programs should use as their tmp directory.
+  @unstable(feature = tmp-dir)
+  tmp-dir: func() -> option<string>;
 }


### PR DESCRIPTION
Allow a temporary directory to be specified. This will prevent the panic from std::env::temp_dir().
https://github.com/rust-lang/rust/blob/master/library/std/src/sys/pal/wasi/os.rs#L266-L268

https://bytecodealliance.zulipchat.com/#narrow/channel/219900-wasi/topic/tempfile.3A.3Atempdir.20panics