### PR TITLE
Add `get-*` prefix

### DIFF
--- a/wit-0.3.0-draft/environment.wit
+++ b/wit-0.3.0-draft/environment.wit
@@ -18,5 +18,5 @@ interface environment {
   /// Return a path that programs should use as their initial current working
   /// directory, interpreting `.` as shorthand for this.
   @since(version = 0.3.0)
-  initial-cwd: func() -> option<string>;
+  get-initial-cwd: func() -> option<string>;
 }


### PR DESCRIPTION
As proposed in a [previous WASI meeting](https://docs.google.com/presentation/d/1on-QuMkOQ-2GCFcJG0DulxKIEDN4KrxveD--gFIzWyQ/edit?usp=sharing), this PR prefixes property-like methods with `get-`.
