### PR TITLE
Flag `wasi:cli/run#run` as an async function

### DIFF
--- a/wit-0.3.0-draft/run.wit
+++ b/wit-0.3.0-draft/run.wit
@@ -2,5 +2,5 @@
 interface run {
   /// Run the program.
   @since(version = 0.3.0-rc-2025-08-15)
-  run: func() -> result;
+  run: async func() -> result;
 }


### PR DESCRIPTION
I think this was lost in various translations here and there, but I'm under the impression that the intention is that this is should be `async`-by-default.