### PR TITLE
[p3] Rename `wasi:cli/std{out,err}#set-std{out,err}`

### DIFF
--- a/wit-0.3.0-draft/stdio.wit
+++ b/wit-0.3.0-draft/stdio.wit
@@ -7,11 +7,11 @@ interface stdin {
 @since(version = 0.3.0-rc-2025-08-15)
 interface stdout {
   @since(version = 0.3.0-rc-2025-08-15)
-  set-stdout: func(data: stream<u8>);
+  append-stdout: func(data: stream<u8>);
 }
 
 @since(version = 0.3.0-rc-2025-08-15)
 interface stderr {
   @since(version = 0.3.0-rc-2025-08-15)
-  set-stderr: func(data: stream<u8>);
+  append-stderr: func(data: stream<u8>);
 }


### PR DESCRIPTION
Use "append" instead of "set" to help indicate that the output of the stream is appended to stdout/stderr as opposed to only one stream being read at a time.