### PR TITLE
stdio: Update interfaces to support error results

### DIFF
--- a/wit-0.3.0-draft/stdio.wit
+++ b/wit-0.3.0-draft/stdio.wit
@@ -27,12 +27,12 @@ interface stdin {
   /// Multiple streams may be active at the same time. The behavior of concurrent
   /// reads is implementation-specific.
   @since(version = 0.3.0-rc-2025-08-15)
-  read-stdin: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
+  read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
 }
 
 @since(version = 0.3.0-rc-2025-08-15)
 interface stdout {
-  /// Append from the given stream to stdout.
+  /// Write the given stream to stdout.
   ///
   /// If the stream's writable end is dropped this function will either return
   /// success once the entire contents of the stream have been written or an
@@ -41,12 +41,12 @@ interface stdout {
   /// Otherwise if there is an error the readable end of the stream will be
   /// dropped and this function will return an error-code.
   @since(version = 0.3.0-rc-2025-08-15)
-  append-stdout: async func(data: stream<u8>) -> result<_, error-code>;
+  write-via-stream: async func(data: stream<u8>) -> result<_, error-code>;
 }
 
 @since(version = 0.3.0-rc-2025-08-15)
 interface stderr {
-  /// Append from the given stream to stderr.
+  /// Write the given stream to stderr.
   ///
   /// If the stream's writable end is dropped this function will either return
   /// success once the entire contents of the stream have been written or an
@@ -55,5 +55,5 @@ interface stderr {
   /// Otherwise if there is an error the readable end of the stream will be
   /// dropped and this function will return an error-code.
   @since(version = 0.3.0-rc-2025-08-15)
-  append-stderr: async func(data: stream<u8>) -> result<_, error-code>;
+  write-via-stream: async func(data: stream<u8>) -> result<_, error-code>;
 }

--- a/wit-0.3.0-draft/stdio.wit
+++ b/wit-0.3.0-draft/stdio.wit
@@ -1,17 +1,59 @@
 @since(version = 0.3.0-rc-2025-08-15)
-interface stdin {
+interface stdio {
   @since(version = 0.3.0-rc-2025-08-15)
-  get-stdin: func() -> stream<u8>;
+  enum error-code {
+    /// Input/output error
+    io,
+    /// Invalid or incomplete multibyte or wide character
+    illegal-byte-sequence,
+    /// Broken pipe
+    pipe,
+  }
+}
+
+@since(version = 0.3.0-rc-2025-08-15)
+interface stdin {
+  /// Return a stream for reading from stdin.
+  ///
+  /// This function returns a stream which provides data read from stdin,
+  /// and a future to signal read results.
+  ///
+  /// If the stream's readable end is dropped the future will resolve to success.
+  ///
+  /// If the stream's writable end is dropped the future will either resolve to
+  /// success if stdin was closed by the writer or to an error-code if reading
+  /// failed for some other reason.
+  ///
+  /// Multiple streams may be active at the same time. The behavior of concurrent
+  /// reads is implementation-specific.
+  @since(version = 0.3.0-rc-2025-08-15)
+  read-stdin: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
 }
 
 @since(version = 0.3.0-rc-2025-08-15)
 interface stdout {
+  /// Append from the given stream to stdout.
+  ///
+  /// If the stream's writable end is dropped this function will either return
+  /// success once the entire contents of the stream have been written or an
+  /// error-code representing a failure.
+  ///
+  /// Otherwise if there is an error the readable end of the stream will be
+  /// dropped and this function will return an error-code.
   @since(version = 0.3.0-rc-2025-08-15)
-  set-stdout: func(data: stream<u8>);
+  append-stdout: async func(data: stream<u8>) -> result<_, error-code>;
 }
 
 @since(version = 0.3.0-rc-2025-08-15)
 interface stderr {
+  /// Append from the given stream to stderr.
+  ///
+  /// If the stream's writable end is dropped this function will either return
+  /// success once the entire contents of the stream have been written or an
+  /// error-code representing a failure.
+  ///
+  /// Otherwise if there is an error the readable end of the stream will be
+  /// dropped and this function will return an error-code.
   @since(version = 0.3.0-rc-2025-08-15)
-  set-stderr: func(data: stream<u8>);
+  append-stderr: async func(data: stream<u8>) -> result<_, error-code>;
 }


### PR DESCRIPTION
Adapted from `wasi:filesystem/types@0.3.0-rc-2025-08-15` [`descriptor.read-via-stream`](https://github.com/WebAssembly/wasi-filesystem/blob/d81d6256c271fe1c8937eb8353e2ddc25517c153/wit-0.3.0-draft/types.wit#L295-L315) / [`append-via-stream`](https://github.com/WebAssembly/wasi-filesystem/blob/d81d6256c271fe1c8937eb8353e2ddc25517c153/wit-0.3.0-draft/types.wit#L337-L346).

Fixes #81 